### PR TITLE
Handle overflow when getting finalized block

### DIFF
--- a/pkg/listener/chain_listener.go
+++ b/pkg/listener/chain_listener.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
-	"strconv"
 	"time"
 
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -15,6 +14,7 @@ import (
 	"github.com/ronin-chain/ronin-random-beacon/pkg/contract"
 	"github.com/ronin-chain/ronin-random-beacon/pkg/db"
 	"github.com/ronin-chain/ronin-random-beacon/pkg/event"
+	"github.com/ronin-chain/ronin-random-beacon/pkg/utils"
 )
 
 const (
@@ -119,12 +119,8 @@ func (l *ChainListener) getFinalizedBlockNumber(rpcEndpoint string) (uint64, err
 		return 0, err
 	}
 
-	number, err := strconv.ParseUint(rs.Result.Number[2:], 16, 64)
-	if err != nil {
-		return 0, err
-	}
-
-	return number - BufferBlock, nil // Add a little buffer 2 blocks for avoiding reorg in RequestRandom.
+	number, err := utils.ConvertHexaStringToIntWithBuffer(rs.Result.Number, BufferBlock)
+	return number, err
 }
 
 // Syncs latest block number.

--- a/pkg/listener/chain_listener.go
+++ b/pkg/listener/chain_listener.go
@@ -119,7 +119,7 @@ func (l *ChainListener) getFinalizedBlockNumber(rpcEndpoint string) (uint64, err
 		return 0, err
 	}
 
-	number, err := utils.ConvertHexaStringToIntWithBuffer(rs.Result.Number, BufferBlock)
+	number, err := utils.ParseBlockNumberWithOptionalDelay(rs.Result.Number, BufferBlock)
 	return number, err
 }
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -46,7 +46,8 @@ func Max(a, b uint64) uint64 {
 	return b
 }
 
-func ConvertHexaStringToIntWithBuffer(s string, buffer uint64) (uint64, error) {
+// Convert HexString to Uin64 with optional delay, delay is subtracted from the result.
+func ParseBlockNumberWithOptionalDelay(s string, delay uint64) (uint64, error) {
 	s = strings.TrimSpace(s)
 	// Strip the "0x" prefix if present
 	if strings.HasPrefix(s, "0x") {
@@ -61,8 +62,8 @@ func ConvertHexaStringToIntWithBuffer(s string, buffer uint64) (uint64, error) {
 	if err != nil {
 		return 0, err
 	}
-	if number < buffer {
+	if number < delay {
 		return 0, fmt.Errorf("invalid hexa string %s", s)
 	}
-	return number - buffer, nil
+	return number - delay, nil
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"fmt"
 	"math/big"
+	"strconv"
 	"strings"
 
 	"github.com/ethereum/go-ethereum/crypto"
@@ -43,4 +44,25 @@ func Max(a, b uint64) uint64 {
 		return a
 	}
 	return b
+}
+
+func ConvertHexaStringToIntWithBuffer(s string, buffer uint64) (uint64, error) {
+	s = strings.TrimSpace(s)
+	// Strip the "0x" prefix if present
+	if strings.HasPrefix(s, "0x") {
+		s = s[2:]
+	}
+
+	if len(s) == 0 {
+		return 0, fmt.Errorf("invalid hexa string %s", s)
+	}
+
+	number, err := strconv.ParseUint(s, 16, 64)
+	if err != nil {
+		return 0, err
+	}
+	if number < buffer {
+		return 0, fmt.Errorf("invalid hexa string %s", s)
+	}
+	return number - buffer, nil
 }

--- a/tests/util_test.go
+++ b/tests/util_test.go
@@ -60,7 +60,7 @@ func TestMax(t *testing.T) {
 	}
 }
 
-func TestConvertHexaStringToIntWithBuffer(t *testing.T) {
+func TestParseBlockNumberWithOptionalDelay(t *testing.T) {
 	const (
 		bufferBlock = 2
 	)
@@ -75,6 +75,7 @@ func TestConvertHexaStringToIntWithBuffer(t *testing.T) {
 		{"0x1234", bufferBlock, 4658, ""},
 		{"  0x1234  ", bufferBlock, 4658, ""},
 		{" 1234", bufferBlock, 4658, ""},
+		{"0x1234", 0, 4660, ""},
 		{"0x1", bufferBlock, 0, "invalid hexa string"},
 		{"0x", bufferBlock, 0, "invalid hexa string"},
 		{"    ", bufferBlock, 0, "invalid hexa string"},
@@ -83,7 +84,7 @@ func TestConvertHexaStringToIntWithBuffer(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		result, err := utils.ConvertHexaStringToIntWithBuffer(tc.input, tc.buffer)
+		result, err := utils.ParseBlockNumberWithOptionalDelay(tc.input, tc.buffer)
 		if result != tc.expected {
 			t.Errorf("ConvertHexaStringToIntWithBuffer(%q, %v) = %v; want %v", tc.input, tc.buffer, result, tc.expected)
 		}

--- a/tests/util_test.go
+++ b/tests/util_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"math/big"
+	"strings"
 	"testing"
 
 	"github.com/ronin-chain/ronin-random-beacon/pkg/utils"
@@ -55,6 +56,46 @@ func TestMax(t *testing.T) {
 		result := utils.Max(tc.a, tc.b)
 		if result != tc.expected {
 			t.Errorf("Max(%v, %v) = %v; want %v", tc.a, tc.b, result, tc.expected)
+		}
+	}
+}
+
+func TestConvertHexaStringToIntWithBuffer(t *testing.T) {
+	const (
+		bufferBlock = 2
+	)
+	testCases := []struct {
+		input        string
+		buffer       uint64
+		expected     uint64
+		errorMessage string
+	}{
+		{"0x0", bufferBlock, 0, "invalid hexa string"},
+		{"0x11", bufferBlock, 15, ""},
+		{"0x1234", bufferBlock, 4658, ""},
+		{"  0x1234  ", bufferBlock, 4658, ""},
+		{" 1234", bufferBlock, 4658, ""},
+		{"0x1", bufferBlock, 0, "invalid hexa string"},
+		{"0x", bufferBlock, 0, "invalid hexa string"},
+		{"    ", bufferBlock, 0, "invalid hexa string"},
+		{" ", bufferBlock, 0, "invalid hexa string"},
+		{"", bufferBlock, 0, "invalid hexa string"},
+	}
+
+	for _, tc := range testCases {
+		result, err := utils.ConvertHexaStringToIntWithBuffer(tc.input, tc.buffer)
+		if result != tc.expected {
+			t.Errorf("ConvertHexaStringToIntWithBuffer(%q, %v) = %v; want %v", tc.input, tc.buffer, result, tc.expected)
+		}
+
+		if tc.errorMessage == "" {
+			if err != nil {
+				t.Errorf("ConvertHexaStringToIntWithBuffer(%q, %v) got error %v; want nil ", tc.input, tc.buffer, err)
+			}
+		} else {
+			if !strings.Contains(err.Error(), tc.errorMessage) {
+				t.Errorf("ConvertHexaStringToIntWithBuffer(%q, %v) got error %v; want %v ", tc.input, tc.buffer, err, tc.errorMessage)
+			}
 		}
 	}
 }


### PR DESCRIPTION
![telegram-cloud-photo-size-4-5933536124909764651-y](https://github.com/user-attachments/assets/8d735846-9669-41af-ba23-38cf3f743eec)

Got an overflow issue when some how data returned 0 after converting data from RPC nodes.
```
uint64(-2)  = 18446744073709551614.
```